### PR TITLE
Use python-pip-whl as pip base package

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -67,7 +67,7 @@ bootstrap__mandatory_packages:
 #
 # Base packages installed during bootstrap.
 bootstrap__base_packages:
-  - 'python-pip'
+  - 'python-pip-whl'
   - 'sudo'
   - 'lsb-release'
   - 'dbus'


### PR DESCRIPTION
Due to the `python-pip` apt package being superseded by `python-pip-whl` in Focal, we should change the bootstrap script to use that package instead. The package should be available from Xenial and forward.