### PR TITLE
rollback to python-pip package

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -67,7 +67,7 @@ bootstrap__mandatory_packages:
 #
 # Base packages installed during bootstrap.
 bootstrap__base_packages:
-  - 'python-pip-whl'
+  - 'python-pip'
   - 'sudo'
   - 'lsb-release'
   - 'dbus'


### PR DESCRIPTION
Turns out it's not as simple as changing the package to `python-pip-whl`, so rolling back this change for now, until we can make something that's compatible with Ubuntu Focal.